### PR TITLE
fix: FFI「外」模块与终端 VT 处理做平台隔离，支持 macOS/Linux 构建

### DIFF
--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -14,9 +14,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
-	"unsafe"
 	"xuantie/ast"
 	"xuantie/lexer"
 	"xuantie/object"
@@ -1748,14 +1746,14 @@ func evalMemberCallExpression(mce *ast.MemberCallExpression, env map[string]obje
 						return newError(mce.GetLine(), "加载期望 1 个参数")
 					}
 					libPath := args[0].Inspect()
-					dll, err := syscall.LoadDLL(libPath)
+					dllHandle, err := ffiLoadDLL(libPath)
 					if err != nil {
 						return &object.Result{IsSuccess: false, Error: &object.String{Value: err.Error()}}
 					}
 					// 返回一个包装了 DLL 句柄的字典
 					res := &object.Dict{Pairs: make(map[string]object.Object)}
 					res.Pairs["__HANDLE__"] = &object.String{Value: "DLL"} // 标记类型
-					res.Pairs["__PTR__"] = &object.Integer{Value: int64(uintptr(dll.Handle))}
+					res.Pairs["__PTR__"] = &object.Integer{Value: int64(dllHandle)}
 					res.Pairs["__PATH__"] = &object.String{Value: libPath}
 					return &object.Result{IsSuccess: true, Value: res}
 				}
@@ -1883,34 +1881,11 @@ func evalMemberCallExpression(mce *ast.MemberCallExpression, env map[string]obje
 
 			fn := &object.Builtin{
 				Fn: func(fArgs ...object.Object) object.Object {
-					dll := &syscall.DLL{Name: path, Handle: syscall.Handle(ptr)}
-					proc, err := dll.FindProc(procName)
+					r1, err := ffiCall(uintptr(ptr), path, procName, fArgs)
 					if err != nil {
 						return &object.Result{IsSuccess: false, Error: &object.String{Value: err.Error()}}
 					}
-
-					// 转换参数为 uintptr
-					uArgs := make([]uintptr, len(fArgs))
-					for i, a := range fArgs {
-						switch v := a.(type) {
-						case *object.Integer:
-							uArgs[i] = uintptr(v.Value)
-						case *object.String:
-							// 自动检测：如果函数名以 W 结尾，使用 UTF-16 编码，否则使用本地字节编码
-							if strings.HasSuffix(procName, "W") {
-								p, _ := syscall.UTF16PtrFromString(v.Value)
-								uArgs[i] = uintptr(unsafe.Pointer(p))
-							} else {
-								p, _ := syscall.BytePtrFromString(v.Value)
-								uArgs[i] = uintptr(unsafe.Pointer(p))
-							}
-						default:
-							uArgs[i] = 0
-						}
-					}
-
-					r1, _, _ := proc.Call(uArgs...)
-					return &object.Integer{Value: int64(r1)}
+					return &object.Integer{Value: r1}
 				},
 			}
 
@@ -2491,36 +2466,12 @@ func applyFunctionWithGenerics(line int, name string, fn object.Object, args []o
 
 		return result
 	case *object.FFIFunction:
-		dll := &syscall.DLL{Name: function.Path, Handle: syscall.Handle(function.Handle)}
-		proc, err := dll.FindProc(function.Name)
+		r1, err := ffiCall(function.Handle, function.Path, function.Name, args)
 		if err != nil {
 			return &object.Result{IsSuccess: false, Error: &object.String{Value: err.Error()}}
 		}
-
-		// 转换参数为 uintptr
-		uArgs := make([]uintptr, len(args))
-		for i, a := range args {
-			// 如果有原型定义，可以进行类型检查（这里暂时简化，直接转换）
-			switch v := a.(type) {
-			case *object.Integer:
-				uArgs[i] = uintptr(v.Value)
-			case *object.String:
-				// 自动检测：如果函数名以 W 结尾，使用 UTF-16 编码，否则使用本地字节编码
-				if strings.HasSuffix(function.Name, "W") {
-					p, _ := syscall.UTF16PtrFromString(v.Value)
-					uArgs[i] = uintptr(unsafe.Pointer(p))
-				} else {
-					p, _ := syscall.BytePtrFromString(v.Value)
-					uArgs[i] = uintptr(unsafe.Pointer(p))
-				}
-			default:
-				uArgs[i] = 0
-			}
-		}
-
-		r1, _, _ := proc.Call(uArgs...)
 		// 如果有返回类型定义，可以按需转换。目前统一转为整数。
-		return &object.Integer{Value: int64(r1)}
+		return &object.Integer{Value: r1}
 
 	case *object.Builtin:
 		res := function.Fn(args...)

--- a/evaluator/ffi_other.go
+++ b/evaluator/ffi_other.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+// FFI「外」模块——非 Windows 平台暂不支持 DLL 调用。
+// 玄铁 FFI 目前依赖 Windows syscall（LoadDLL/DLL/FindProc），
+// 在 macOS / Linux 上构建时使用本存根，运行时返回明确错误。
+package evaluator
+
+import (
+	"errors"
+
+	"xuantie/object"
+)
+
+var errFFIUnsupported = errors.New("FFI(DLL) 暂不支持当前平台（仅 Windows）")
+
+func ffiLoadDLL(libPath string) (uintptr, error) {
+	return 0, errFFIUnsupported
+}
+
+func ffiCall(handle uintptr, path, procName string, args []object.Object) (int64, error) {
+	return 0, errFFIUnsupported
+}

--- a/evaluator/ffi_windows.go
+++ b/evaluator/ffi_windows.go
@@ -1,0 +1,53 @@
+//go:build windows
+
+// FFI「外」模块——Windows DLL 加载与调用（原生实现）。
+// 与 ffi_other.go 二选一：本文件只在 Windows 编译。
+package evaluator
+
+import (
+	"strings"
+	"syscall"
+	"unsafe"
+
+	"xuantie/object"
+)
+
+// ffiLoadDLL 加载 DLL 并返回句柄。
+func ffiLoadDLL(libPath string) (uintptr, error) {
+	dll, err := syscall.LoadDLL(libPath)
+	if err != nil {
+		return 0, err
+	}
+	return uintptr(dll.Handle), nil
+}
+
+// ffiCall 调用 DLL 导出函数，返回整数结果。
+// 字符串参数按函数名是否以 W 结尾决定 UTF-16 / 本地字节编码。
+func ffiCall(handle uintptr, path, procName string, args []object.Object) (int64, error) {
+	dll := &syscall.DLL{Name: path, Handle: syscall.Handle(handle)}
+	proc, err := dll.FindProc(procName)
+	if err != nil {
+		return 0, err
+	}
+
+	uArgs := make([]uintptr, len(args))
+	for i, a := range args {
+		switch v := a.(type) {
+		case *object.Integer:
+			uArgs[i] = uintptr(v.Value)
+		case *object.String:
+			if strings.HasSuffix(procName, "W") {
+				p, _ := syscall.UTF16PtrFromString(v.Value)
+				uArgs[i] = uintptr(unsafe.Pointer(p))
+			} else {
+				p, _ := syscall.BytePtrFromString(v.Value)
+				uArgs[i] = uintptr(unsafe.Pointer(p))
+			}
+		default:
+			uArgs[i] = 0
+		}
+	}
+
+	r1, _, _ := proc.Call(uArgs...)
+	return int64(r1), nil
+}

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"syscall"
 	"xuantie/ast"
 	"xuantie/compiler"
 	"xuantie/evaluator"
@@ -24,27 +23,6 @@ const (
 	colorRed   = "\033[31m"
 	colorBold  = "\033[1m"
 )
-
-func enableVirtualTerminalProcessing() {
-	if runtime.GOOS != "windows" {
-		return
-	}
-	const enableVirtualTerminalProcessingMode = 0x0004
-	var (
-		handle syscall.Handle
-		mode   uint32
-	)
-	handle = syscall.Handle(os.Stdout.Fd())
-	if err := syscall.GetConsoleMode(handle, &mode); err == nil {
-		mode |= enableVirtualTerminalProcessingMode
-		syscall.Syscall(syscall.NewLazyDLL("kernel32.dll").NewProc("SetConsoleMode").Addr(), 2, uintptr(handle), uintptr(mode), 0)
-	}
-	handle = syscall.Handle(os.Stderr.Fd())
-	if err := syscall.GetConsoleMode(handle, &mode); err == nil {
-		mode |= enableVirtualTerminalProcessingMode
-		syscall.Syscall(syscall.NewLazyDLL("kernel32.dll").NewProc("SetConsoleMode").Addr(), 2, uintptr(handle), uintptr(mode), 0)
-	}
-}
 
 func isPowerShell() bool {
 	return runtime.GOOS == "windows" || os.Getenv("PSModulePath") != ""

--- a/term_other.go
+++ b/term_other.go
@@ -1,0 +1,6 @@
+//go:build !windows
+
+// 非 Windows 平台：无需启用控制台 VT 处理（空实现）。
+package main
+
+func enableVirtualTerminalProcessing() {}

--- a/term_windows.go
+++ b/term_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+// Windows 控制台 VT 处理（原生实现）。与 term_other.go 二选一。
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func enableVirtualTerminalProcessing() {
+	const enableVirtualTerminalProcessingMode = 0x0004
+	var (
+		handle syscall.Handle
+		mode   uint32
+	)
+	handle = syscall.Handle(os.Stdout.Fd())
+	if err := syscall.GetConsoleMode(handle, &mode); err == nil {
+		mode |= enableVirtualTerminalProcessingMode
+		syscall.Syscall(syscall.NewLazyDLL("kernel32.dll").NewProc("SetConsoleMode").Addr(), 2, uintptr(handle), uintptr(mode), 0)
+	}
+	handle = syscall.Handle(os.Stderr.Fd())
+	if err := syscall.GetConsoleMode(handle, &mode); err == nil {
+		mode |= enableVirtualTerminalProcessingMode
+		syscall.Syscall(syscall.NewLazyDLL("kernel32.dll").NewProc("SetConsoleMode").Addr(), 2, uintptr(handle), uintptr(mode), 0)
+	}
+}


### PR DESCRIPTION
## 背景

关联 #3：FFI「外」模块与终端 VT 处理使用 Windows 专用 syscall 且未做平台隔离，导致 macOS / Linux 上 `go build` 失败（`undefined: syscall.LoadDLL` / `syscall.DLL` / `syscall.GetConsoleMode` 等）。

## 改动

1. **evaluator/**：拆出平台文件
   - `ffi_windows.go`（`//go:build windows`）：保留原 LoadDLL / FindProc / Call 逻辑
   - `ffi_other.go`（`//go:build !windows`）：调用「外」时返回"FFI(DLL) 暂不支持当前平台（仅 Windows）"
   - `evaluator.go` 三处 FFI 调用改用封装函数 `ffiLoadDLL` / `ffiCall`，不再直接引用 syscall

2. **main.go**：移除 `enableVirtualTerminalProcessing` 的 syscall 实现，拆为
   - `term_windows.go`（`//go:build windows`）：原实现
   - `term_other.go`（`//go:build !windows`）：空实现

## 验证

- macOS arm64：`go build` 通过，运行正常（`示()` / 算术 / 猜数字项目）
- Linux x86_64（Arch Linux）：`go build` 通过，运行正常
- Windows 逻辑未改动（原代码移入 `_windows.go` 平台文件）

Closes #3
