### PR TITLE
fix: 外函返回小数的值未装箱，LLVM 后端 xt_retain 类型错误

### DIFF
--- a/compiler/llvm.go
+++ b/compiler/llvm.go
@@ -1533,6 +1533,16 @@ func (c *LLVMCompiler) compileExpression(expr ast.Expression) (string, string, s
 				return rawRes, "raw_i64", ""
 			}
 		}
+		// 小数（浮点）返回值需要打包成 XTFloat 对象（玄铁运行时浮点装箱），
+		// 否则裸 double 被 xt_retain(i64) / ret i64 使用会产生 LLVM 类型错误
+		// （与 ensureI64 中 double → xt_float_new 的处理对齐）。
+		if declaredRetType == "double" {
+			packed := c.nextReg()
+			c.emit("  %s = call i8* @xt_float_new(double %s)", packed, reg)
+			ptrI64 := c.nextReg()
+			c.emit("  %s = ptrtoint i8* %s to i64", ptrI64, packed)
+			return ptrI64, "i64", ""
+		}
 		return reg, declaredRetType, ""
 	case *ast.NewExpression:
 		reg := c.nextReg()


### PR DESCRIPTION
## 问题

修复 #7。

外函（`外 函`）声明返回「小数」(double) 时，LLVM 后端直接把裸 double 当作 i64 对象使用：

```llvm
; 修复前（bug）
%t20 = call double @"XT_GetFrameTime"()
call void @xt_retain(i64 %t20)   ; %t20 是 double，报类型错误
ret i64 %t20                     ; 返回类型也是 i64，仍指向 double
```

导致编译报错：

```
LLVM 编译为对象文件失败: exit status 1
错误详情: Test/96_渲染窗口帧循环.ll:337:28: error: '%t20' defined with type 'double' but expected 'i64'
```

## 根因

在 `compiler/llvm.go` 的函数调用表达式处理中，外函返回值直接以声明类型（`declaredRetType`）返回。当外函返回 `小数`（映射为 LLVM `double`）时，裸 double 未经装箱就流入玄铁对象层（`xt_retain`/`ret`），而玄铁运行时浮点必须装箱为 XTFloat 对象。

## 修复

将 `double` 返回值用 `xt_float_new` 打包成 XTFloat 对象，再转 i64 标记指针返回——与 `ensureI64` 中已有的 double 处理方式对齐：

```llvm
; 修复后
%t20 = call double @"XT_GetFrameTime"()
%t21 = call i8* @xt_float_new(double %t20)  ; 装箱 XTFloat
%t22 = ptrtoint i8* %t21 to i64             ; 转 i64 标记指针
call void @xt_retain(i64 %t22)              ; 类型正确
ret i64 %t22                                ; 类型正确
```

## 影响

影响所有返回 `小数` 的外函，例如渲染库（`取帧时间`、`取运行时间` 等）。此 bug 导致渲染库在 macOS/Linux（Go 种子版编译器）上 tie 编译失败；Windows 自举版编译器（xtc）已正确处理，不受影响。

## 验证

- 环境：macOS arm64，Apple clang 21.0.0，Go 种子版编译器
- `go build` 通过
- `xuantie tie Test/96_渲染窗口帧循环.xt`：LLVM IR 生成通过（修复前在此报 double/i64 类型错误）
- 生成的 IR 经 `clang -target x86_64-w64-windows-gnu -c` 编译为对象文件成功（exit 0）

> 注：macOS 上 tie 的完整链接链路（main.go 中 clang/gcc 调用）目前仍按 Windows 目标硬编码，链接阶段在 macOS 上暂未适配，属另一独立问题。本 PR 聚焦 LLVM IR 生成阶段的类型错误。

---
人类已在 Agent 对话中审核本 PR 内容。
提交环境：豆包 Mac 版 | 模型：Auto | 推理强度：高
认证方式：GitHub Personal Access Token (classic)